### PR TITLE
feat: 모임 생성 페이지 기능 보완

### DIFF
--- a/src/components/mbti_meeting/MbtiMeetingCreateInfo.jsx
+++ b/src/components/mbti_meeting/MbtiMeetingCreateInfo.jsx
@@ -38,7 +38,7 @@ const MbtiMeetingCreateInfo = () => {
             <StTopContainer>
                 <StImgBox>
                     <StImg>
-                        {newMeeting.repreImg ? (
+                        {newMeeting && newMeeting.repreImg ? (
                             <img
                                 src={newMeeting.repreImg}
                                 alt="선택된 이미지"
@@ -62,8 +62,9 @@ const MbtiMeetingCreateInfo = () => {
                             <StDetailTextBox>
                                 모임 이름
                                 <StDetailText
-                                    placeholder="모임의 이름을 입력해주세요."
-                                    value={newMeeting.name || ''}
+                                    placeholder="모임의 이름을 입력해주세요.(15자 이내)"
+                                    maxLength={15}
+                                    value={newMeeting && newMeeting.name ? newMeeting.name : ''}
                                     onChange={(e) =>
                                         setNewMeeting((prevNewMeeting) => ({
                                             ...prevNewMeeting,
@@ -76,7 +77,7 @@ const MbtiMeetingCreateInfo = () => {
                                 모집 관리자
                                 <StDetailText
                                     placeholder="모임의 관리자 이름을 입력해주세요."
-                                    value={newMeeting.managerName || ''}
+                                    value={newMeeting && newMeeting.managerName ? newMeeting.managerName : ''}
                                     onChange={(e) =>
                                         setNewMeeting((prevNewMeeting) => ({
                                             ...prevNewMeeting,
@@ -91,7 +92,7 @@ const MbtiMeetingCreateInfo = () => {
                                 모임 정원
                                 <StDetailText
                                     placeholder="모임의 정원을 입력해주세요. (ex. 10명)"
-                                    value={newMeeting.limitPeople || ''}
+                                    value={newMeeting && newMeeting.limitPeople ? newMeeting.limitPeople : ''}
                                     onChange={(e) =>
                                         setNewMeeting((prevNewMeeting) => ({
                                             ...prevNewMeeting,
@@ -104,7 +105,7 @@ const MbtiMeetingCreateInfo = () => {
                                 모임 일정
                                 <StDetailText
                                     placeholder="모임의 일정을 입력해주세요. (ex. 주 5회)"
-                                    value={newMeeting.schedule || ''}
+                                    value={newMeeting && newMeeting.schedule ? newMeeting.schedule : ''}
                                     onChange={(e) =>
                                         setNewMeeting((prevNewMeeting) => ({
                                             ...prevNewMeeting,
@@ -117,7 +118,7 @@ const MbtiMeetingCreateInfo = () => {
                         <StDetailTextBox3>1:1 오픈 채팅방 만드는 방법</StDetailTextBox3>
                         <StDetailText3
                             placeholder="카카오톡 오픈채팅방의 URL을 입력해주세요."
-                            value={newMeeting.kakaoUrl || ''}
+                            value={newMeeting && newMeeting.kakaoUrl ? newMeeting.kakaoUrl : ''}
                             onChange={(e) =>
                                 setNewMeeting((prevNewMeeting) => ({
                                     ...prevNewMeeting,
@@ -129,7 +130,7 @@ const MbtiMeetingCreateInfo = () => {
                             모임 한줄 소개
                             <StDetailText2
                                 placeholder="모임에 대해 간단하게 소개해주세요."
-                                value={newMeeting.oneLineIntro || ''}
+                                value={newMeeting && newMeeting.oneLineIntro ? newMeeting.oneLineIntro : ''}
                                 onChange={(e) =>
                                     setNewMeeting((prevNewMeeting) => ({
                                         ...prevNewMeeting,

--- a/src/components/mbti_meeting/MbtiMeetingCreateTags.jsx
+++ b/src/components/mbti_meeting/MbtiMeetingCreateTags.jsx
@@ -7,9 +7,9 @@ function MbtiMeetingCreateTags() {
     const [newMeeting, setNewMeeting] = useRecoilState(createMeetingState);
     const location01 = ['전지역', '서울', '인천', '대전', '광주', '대구', '부산', '울산'];
     const location02 = ['경기', '강원', '충북', '충남', '전북', '전남', '경북', '경남', '제주'];
-    const gender = ['남자', '여자', '남/여'];
-    const age = ['10대', '20대', '30대', '40대', '50대 이상'];
-    const mbti = ['E', 'I', 'N', 'S', 'F', 'T', 'P', 'J'];
+    const gender = ['남/여', '남자', '여자'];
+    const age = ['전연령', '10대', '20대', '30대', '40대', '50대 이상'];
+    const mbti = ['모든 유형', 'E', 'I', 'N', 'S', 'F', 'T', 'P', 'J'];
 
     return (
         <StTopContainerBox>

--- a/src/components/mbti_meeting/MbtiMeetingExplainMeeting.jsx
+++ b/src/components/mbti_meeting/MbtiMeetingExplainMeeting.jsx
@@ -13,9 +13,8 @@ const MbtiMeetingExplainMeeting = () => {
             <StTitle>모임 설명</StTitle>
             <StBox>
                 <StPeedTitle
-                    placeholder="제목을 입력해주세요.(15글자)"
-                    maxLength={15}
-                    value={newMeeting.title || ''}
+                    placeholder="제목을 입력해주세요."
+                    value={newMeeting && newMeeting.title ? newMeeting.title : ''}
                     onChange={(e) =>
                         setNewMeeting((prevNewMeeting) => ({
                             ...prevNewMeeting,
@@ -25,7 +24,9 @@ const MbtiMeetingExplainMeeting = () => {
                 ></StPeedTitle>
                 <StPeedContent
                     placeholder="내용을 입력해주세요."
-                    value={newMeeting.content || ''}
+                    cols="40"
+                    rows="8"
+                    value={newMeeting && newMeeting.content ? newMeeting.content : ''}
                     onChange={(e) =>
                         setNewMeeting((prevNewMeeting) => ({
                             ...prevNewMeeting,
@@ -80,7 +81,7 @@ const StPeedTitle = styled.input`
     height: 47px;
     margin-bottom: 14px;
     font-size: 18px;
-    padding: 13px;
+    padding: 14px;
     background-color: var(--light-gray);
     border: none;
     border-radius: 16px;
@@ -90,15 +91,16 @@ const StPeedTitle = styled.input`
     }
 `;
 
-const StPeedContent = styled.input`
+const StPeedContent = styled.textarea`
     width: 100%;
     height: 483px;
     margin-bottom: 14px;
     font-size: 18px;
-    padding: 13px;
+    padding: 40px 14px;
     background-color: var(--light-gray);
     border: none;
     border-radius: 16px;
+    resize: none;
 
     &:focus {
         outline-color: var(--button-border-color);

--- a/src/pages/MbtiMeetingCreatePage.jsx
+++ b/src/pages/MbtiMeetingCreatePage.jsx
@@ -16,11 +16,28 @@ const MbtiMeetingCreatePage = () => {
 
     const createMeetingButtonHandler = async () => {
         try {
-            const meetCollectionRef = await addDoc(collection(db, 'meet'), newMeeting);
+            const currentDate = new Date();
+
+            const year = currentDate.getFullYear();
+            const month = currentDate.getMonth() + 1;
+            const date = currentDate.getDate();
+
+            const updatedMeeting = {
+                ...newMeeting,
+                date: `${year} / ${month} / ${date}`
+            };
+
+            setNewMeeting(updatedMeeting);
+
+            const meetCollectionRef = await addDoc(collection(db, 'meet'), updatedMeeting);
             console.log('모임이 성공적으로 meet 컬렉션에 추가되었습니다.');
+
+            // newMeeting 상태 초기화
+            setNewMeeting(null);
+
             nav('/mbti/meeting');
         } catch (error) {
-            console.error('meet 컬렉션에 meetingData를 추가하는 과정에서 오류가 발생했습니다:', error);
+            console.error('meet 컬렉션에 newMeeting 데이터를 추가하는 과정에서 오류가 발생했습니다:', error);
         }
     };
 


### PR DESCRIPTION
feat: 모임 생성 페이지 기능 보완

- 모임 생성 시, 작성 날짜를 newMeeting 데이터에 담은 상태에서 meet 컬렉션에 추가 (완료)
- 모임 태그 > 누락된 태그 추가 및 순서 보완 (완료)
- 모임 생성 후, 새로운 모임을 생성하려고 할 때 이전 기록이 중복으로 담기는 에러 (완료)
- 모임 생성 > 모임 이름 15자 이내로 제한 (완료)